### PR TITLE
Make CAN Peripherals refcounted, impl Format for BusError, and re-export bus modes

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -438,7 +438,7 @@ fn main() {
     // ========
     // Generate RccPeripheral impls
 
-    let refcounted_peripherals = HashSet::from(["usart", "adc"]);
+    let refcounted_peripherals = HashSet::from(["usart", "adc", "fdcan"]);
     let mut refcount_statics = BTreeSet::new();
 
     for p in METADATA.peripherals {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -438,7 +438,7 @@ fn main() {
     // ========
     // Generate RccPeripheral impls
 
-    let refcounted_peripherals = HashSet::from(["usart", "adc", "fdcan"]);
+    let refcounted_peripherals = HashSet::from(["usart", "adc", "can"]); // wrong way of doing this, looking for kind == "can" will also effect bxcan chips
     let mut refcount_statics = BTreeSet::new();
 
     for p in METADATA.peripherals {

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -438,7 +438,7 @@ fn main() {
     // ========
     // Generate RccPeripheral impls
 
-    let refcounted_peripherals = HashSet::from(["usart", "adc", "can"]); // wrong way of doing this, looking for kind == "can" will also effect bxcan chips
+    let refcounted_peripherals = HashSet::from(["usart", "adc", "can"]);
     let mut refcount_statics = BTreeSet::new();
 
     for p in METADATA.peripherals {

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -194,7 +194,8 @@ impl<T: Instance> interrupt::typelevel::Handler<T::IT1Interrupt> for IT1Interrup
     }
 }
 
-#[derive(Debug, Format)]
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BusError {
     Stuff,
     Form,

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -401,7 +401,7 @@ impl<'d, T: Instance, M: FdcanOperatingMode> Fdcan<'d, T, M>
 }
 
 pub struct FdcanTx<'d, T: Instance, M: fdcan::Transmit> {
-    can: &RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
+    can: &'d RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
 impl<'d, T: Instance, M: fdcan::Transmit> FdcanTx<'d, T, M> {
@@ -442,7 +442,7 @@ impl<'d, T: Instance, M: fdcan::Transmit> FdcanTx<'d, T, M> {
 
 #[allow(dead_code)]
 pub struct FdcanRx<'d, T: Instance, M: fdcan::Receive> {
-    can: &RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
+    can: &'d RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
 impl<'d, T: Instance, M: fdcan::Receive> FdcanRx<'d, T, M> {

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -395,16 +395,16 @@ impl<'d, T: Instance, M: FdcanOperatingMode> Fdcan<'d, T, M>
         None
     }
 
-    pub fn split(self) -> (FdcanTx<'d, T, M>, FdcanRx<'d, T, M>) {
+    pub fn split<'c>(self) -> (FdcanTx<'c, 'd, T, M>, FdcanRx<'c, 'd, T, M>) {
         (FdcanTx { can: &self.can }, FdcanRx { can: &self.can })
     }
 }
 
-pub struct FdcanTx<'d, T: Instance, M: fdcan::Transmit> {
-    can: &'d RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
+pub struct FdcanTx<'c, 'd, T: Instance, M: fdcan::Transmit> {
+    can: &'c RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
-impl<'d, T: Instance, M: fdcan::Transmit> FdcanTx<'d, T, M> {
+impl<'c, 'd, T: Instance, M: fdcan::Transmit> FdcanTx<'c, 'd, T, M> {
     /// Queues the message to be sent but exerts backpressure.  If a lower-priority
     /// frame is dropped from the mailbox, it is returned.  If no lower-priority frames
     /// can be replaced, this call asynchronously waits for a frame to be successfully
@@ -441,11 +441,11 @@ impl<'d, T: Instance, M: fdcan::Transmit> FdcanTx<'d, T, M> {
 }
 
 #[allow(dead_code)]
-pub struct FdcanRx<'d, T: Instance, M: fdcan::Receive> {
-    can: &'d RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
+pub struct FdcanRx<'c, 'd, T: Instance, M: fdcan::Receive> {
+    can: &'c RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
-impl<'d, T: Instance, M: fdcan::Receive> FdcanRx<'d, T, M> {
+impl<'c, 'd, T: Instance, M: fdcan::Receive> FdcanRx<'c, 'd, T, M> {
     /// Returns the next received message frame
     pub async fn read(&mut self) -> Result<RxFrame, BusError> {
         poll_fn(|cx| {

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -194,7 +194,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::IT1Interrupt> for IT1Interrup
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Format)]
 pub enum BusError {
     Stuff,
     Form,

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -364,6 +364,12 @@ impl<'d, T: Instance, M: FdcanOperatingMode> Fdcan<'d, T, M>
                 //  for now we just drop it
                 let frame: RxFrame = RxFrame::new(rx.unwrap(), &buffer);
                 return Poll::Ready(Ok(frame));
+            } else if let Ok(rx) = self.can.borrow_mut().receive1(&mut buffer) {
+                // rx: fdcan::ReceiveOverrun<RxFrameInfo>
+                // TODO: report overrun?
+                //  for now we just drop it
+                let frame: RxFrame = RxFrame::new(rx.unwrap(), &buffer);
+                return Poll::Ready(Ok(frame));
             } else if let Some(err) = self.curr_error() {  // TODO: this is probably wrong
                 return Poll::Ready(Err(err));
             }

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -8,7 +8,7 @@ use cfg_if::cfg_if;
 use fdcan;
 pub use fdcan::frame::{RxFrameInfo, TxFrameHeader, FrameFormat};
 pub use fdcan::id::{StandardId, ExtendedId, Id};
-pub use fdcan::{config, filter};
+pub use fdcan::{config, filter, NormalOperationMode, InternalLoopbackMode, ExternalLoopbackMode, TestMode, ConfigMode, PoweredDownMode, RestrictedOperationMode, BusMonitoringMode};
 use embassy_hal_internal::{into_ref, PeripheralRef};
 use fdcan::message_ram::RegisterBlock;
 use fdcan::LastErrorCode;

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -395,16 +395,16 @@ impl<'d, T: Instance, M: FdcanOperatingMode> Fdcan<'d, T, M>
         None
     }
 
-    pub fn split<'c>(&'c self) -> (FdcanTx<'c, 'd, T, M>, FdcanRx<'c, 'd, T, M>) {
+    pub fn split(self) -> (FdcanTx<'d, T, M>, FdcanRx<'d, T, M>) {
         (FdcanTx { can: &self.can }, FdcanRx { can: &self.can })
     }
 }
 
-pub struct FdcanTx<'c, 'd, T: Instance, M: fdcan::Transmit> {
-    can: &'c RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
+pub struct FdcanTx<'d, T: Instance, M: fdcan::Transmit> {
+    can: &RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
-impl<'c, 'd, T: Instance, M: fdcan::Transmit> FdcanTx<'c, 'd, T, M> {
+impl<'d, T: Instance, M: fdcan::Transmit> FdcanTx<'d, T, M> {
     /// Queues the message to be sent but exerts backpressure.  If a lower-priority
     /// frame is dropped from the mailbox, it is returned.  If no lower-priority frames
     /// can be replaced, this call asynchronously waits for a frame to be successfully
@@ -441,11 +441,11 @@ impl<'c, 'd, T: Instance, M: fdcan::Transmit> FdcanTx<'c, 'd, T, M> {
 }
 
 #[allow(dead_code)]
-pub struct FdcanRx<'c, 'd, T: Instance, M: fdcan::Receive> {
+pub struct FdcanRx<'d, T: Instance, M: fdcan::Receive> {
     can: &'c RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
-impl<'c, 'd, T: Instance, M: fdcan::Receive> FdcanRx<'c, 'd, T, M> {
+impl<'d, T: Instance, M: fdcan::Receive> FdcanRx<'d, T, M> {
     /// Returns the next received message frame
     pub async fn read(&mut self) -> Result<RxFrame, BusError> {
         poll_fn(|cx| {

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -395,7 +395,7 @@ impl<'d, T: Instance, M: FdcanOperatingMode> Fdcan<'d, T, M>
         None
     }
 
-    pub fn split<'c>(self) -> (FdcanTx<'c, 'd, T, M>, FdcanRx<'c, 'd, T, M>) {
+    pub fn split<'c>(&'c self) -> (FdcanTx<'c, 'd, T, M>, FdcanRx<'c, 'd, T, M>) {
         (FdcanTx { can: &self.can }, FdcanRx { can: &self.can })
     }
 }

--- a/embassy-stm32/src/can/fdcan.rs
+++ b/embassy-stm32/src/can/fdcan.rs
@@ -442,7 +442,7 @@ impl<'d, T: Instance, M: fdcan::Transmit> FdcanTx<'d, T, M> {
 
 #[allow(dead_code)]
 pub struct FdcanRx<'d, T: Instance, M: fdcan::Receive> {
-    can: &'c RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
+    can: &RefCell<fdcan::FdCan<FdcanInstance<'d, T>, M>>,
 }
 
 impl<'d, T: Instance, M: fdcan::Receive> FdcanRx<'d, T, M> {


### PR DESCRIPTION
These are all the changes I had to make to get FDCAN1 and FDCAN2 of my H750 working with rx and tx split.

The change to build.rs mentioned [here](https://github.com/embassy-rs/stm32-data/pull/308#issuecomment-1847559058)

Added defmt::Format to BusError so that it can be logged with defmt

re=exported all of the bus modes to be able to do the type annotation to the tasks that are receiving the rx and tx